### PR TITLE
Add compatibility with clustered environments

### DIFF
--- a/src/main/amp/config/alfresco/module/libreoffice-online-repo/alfresco-global.properties
+++ b/src/main/amp/config/alfresco/module/libreoffice-online-repo/alfresco-global.properties
@@ -8,14 +8,14 @@ lool.wopi.url=https://lool.magenta.dk:9980
 lool.wopi.alfresco.host=https://alfedu.magenta.dk
 lool.wopi.url.discovery=https://alfedu.magenta.dk/discovery.xml
 
-lool.cache.fileIdAccessTokenMapSharedCache.tx.maxItems=0
+lool.cache.fileIdAccessTokenMapSharedCache.tx.maxItems=5000
 lool.cache.fileIdAccessTokenMapSharedCache.tx.statsEnabled=${caches.tx.statsEnabled}
-lool.cache.fileIdAccessTokenMapSharedCache.maxItems=0
+lool.cache.fileIdAccessTokenMapSharedCache.maxItems=5000
 lool.cache.fileIdAccessTokenMapSharedCache.timeToLiveSeconds=0
 lool.cache.fileIdAccessTokenMapSharedCache.maxIdleSeconds=0
 lool.cache.fileIdAccessTokenMapSharedCache.cluster.type=fully-distributed
 lool.cache.fileIdAccessTokenMapSharedCache.backup-count=1
-lool.cache.fileIdAccessTokenMapSharedCache.eviction-policy=NONE
+lool.cache.fileIdAccessTokenMapSharedCache.eviction-policy=LRU
 lool.cache.fileIdAccessTokenMapSharedCache.eviction-percentage=25
 lool.cache.fileIdAccessTokenMapSharedCache.merge-policy=hz.ADD_NEW_ENTRY
 lool.cache.fileIdAccessTokenMapSharedCache.readBackupData=false

--- a/src/main/amp/config/alfresco/module/libreoffice-online-repo/alfresco-global.properties
+++ b/src/main/amp/config/alfresco/module/libreoffice-online-repo/alfresco-global.properties
@@ -7,3 +7,15 @@
 lool.wopi.url=https://lool.magenta.dk:9980
 lool.wopi.alfresco.host=https://alfedu.magenta.dk
 lool.wopi.url.discovery=https://alfedu.magenta.dk/discovery.xml
+
+lool.cache.fileIdAccessTokenMapSharedCache.tx.maxItems=0
+lool.cache.fileIdAccessTokenMapSharedCache.tx.statsEnabled=${caches.tx.statsEnabled}
+lool.cache.fileIdAccessTokenMapSharedCache.maxItems=0
+lool.cache.fileIdAccessTokenMapSharedCache.timeToLiveSeconds=0
+lool.cache.fileIdAccessTokenMapSharedCache.maxIdleSeconds=0
+lool.cache.fileIdAccessTokenMapSharedCache.cluster.type=fully-distributed
+lool.cache.fileIdAccessTokenMapSharedCache.backup-count=1
+lool.cache.fileIdAccessTokenMapSharedCache.eviction-policy=NONE
+lool.cache.fileIdAccessTokenMapSharedCache.eviction-percentage=25
+lool.cache.fileIdAccessTokenMapSharedCache.merge-policy=hz.ADD_NEW_ENTRY
+lool.cache.fileIdAccessTokenMapSharedCache.readBackupData=false

--- a/src/main/amp/config/alfresco/module/libreoffice-online-repo/context/service-context.xml
+++ b/src/main/amp/config/alfresco/module/libreoffice-online-repo/context/service-context.xml
@@ -18,10 +18,23 @@
 -->
 <beans>
 
+    <!-- Shared Cache for fileIdAccessTokenMap -->
+    <bean name="lool-fileIdAccessTokenMapSharedCache" factory-bean="cacheFactory" factory-method="createCache">
+        <constructor-arg value="lool.cache.fileIdAccessTokenMapSharedCache"/>
+    </bean>
+    <bean name="lool-fileIdAccessTokenMapCache" class="org.alfresco.repo.cache.TransactionalCache">
+        <property name="sharedCache" ref="lool-fileIdAccessTokenMapSharedCache"/>
+        <property name="name" value="lool-fileIdAccessTokenMapCache"/>
+        <property name="maxCacheSize" value="${lool.cache.fileIdAccessTokenMapSharedCache.tx.maxItems}"/>
+        <property name="cacheStats" ref="cacheStatistics"/>
+        <property name="cacheStatsEnabled" value="${lool.cache.fileIdAccessTokenMapSharedCache.tx.statsEnabled}"/>
+    </bean>
+
     <!-- A simple class that is initialized by Spring -->
     <!--Note that the discovery url is added here for some flexibility-->
     <bean id="LOOLService"
           class="dk.magenta.libreoffice.online.service.LOOLServiceImpl" init-method="init">
+        <property name="fileIdAccessTokenMap" ref="lool-fileIdAccessTokenMapSharedCache"/>
         <property name="wopiBaseURL" value="${lool.wopi.url}"/>
         <property name="wopiDiscoveryURL" value="${lool.wopi.url.discovery}"/>
         <property name="alfExternalHost" value="${lool.wopi.alfresco.host}"/>

--- a/src/main/amp/config/alfresco/module/libreoffice-online-repo/log4j.properties
+++ b/src/main/amp/config/alfresco/module/libreoffice-online-repo/log4j.properties
@@ -38,4 +38,4 @@
 #    
 #-----------------------------------------------------------------------
 
-#log4j.logger.dk.magenta.demoamp.DemoComponent=debug
+log4j.logger.dk.magenta.libreoffice.online=INFO

--- a/src/main/java/dk/magenta/libreoffice/online/service/LOOLServiceImpl.java
+++ b/src/main/java/dk/magenta/libreoffice/online/service/LOOLServiceImpl.java
@@ -3,6 +3,7 @@ package dk.magenta.libreoffice.online.service;
 import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.admin.SysAdminParams;
+import org.alfresco.repo.cache.SimpleCache;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.service.cmr.repository.ContentData;
 import org.alfresco.service.cmr.repository.NodeRef;
@@ -60,10 +61,19 @@ public class LOOLServiceImpl implements LOOLService {
      * is mapped to a user, so in essence a user may only have one token info per
      * file. <FileId, <userName, tokenInfo> >
      * <p>
-     * { fileId: { <== The id of the nodeRef that refers to the file userName:
-     * WOPIAccessTokenInfo } }
+     * { fileId: { <== The id of the nodeRef that refers to the file userName: WOPIAccessTokenInfo } }
+     *
+     *
+     * fileIdAccessTokenMap is an Hazelcast IMap
+     * see: https://docs.hazelcast.org/docs/2.4/javadoc/com/hazelcast/core/IMap.html
+     * The get(Object key) method returns a clone of original value, modifying the returned value does not change
+     * the actual value in the map. One should put modified value back to make changes visible to all nodes.
      */
-    private Map<String, Map<String, WOPIAccessTokenInfo>> fileIdAccessTokenMap = new HashMap<>();
+    private SimpleCache<String, Map<String, WOPIAccessTokenInfo>> fileIdAccessTokenMap;
+
+    public void setFileIdAccessTokenMap(SimpleCache<String, Map<String, WOPIAccessTokenInfo>> fileIdAccessTokenMap) {
+        this.fileIdAccessTokenMap = fileIdAccessTokenMap;
+    }
 
     public void setNodeService(NodeService nodeService) {
         this.nodeService = nodeService;
@@ -96,7 +106,7 @@ public class LOOLServiceImpl implements LOOLService {
         final String userName = AuthenticationUtil.getRunAsUser();
         final Date now = new Date();
         final Date newExpiresAt = new Date(now.getTime() + TOKEN_TTL_MS);
-        final Map<String, WOPIAccessTokenInfo> tokenInfoMap = fileIdAccessTokenMap.get(fileId);
+        Map<String, WOPIAccessTokenInfo> tokenInfoMap = fileIdAccessTokenMap.get(fileId);
 
         WOPIAccessTokenInfo tokenInfo = null;
         if (tokenInfoMap != null) {
@@ -114,11 +124,16 @@ public class LOOLServiceImpl implements LOOLService {
         }
         if (tokenInfo == null) {
             tokenInfo = new WOPIAccessTokenInfo(generateAccessToken(), now, newExpiresAt, fileId, userName);
-            if (fileIdAccessTokenMap.get(fileId) == null) {
-                fileIdAccessTokenMap.put(fileId, new HashMap<String, WOPIAccessTokenInfo>());
+            if(tokenInfoMap == null) {
+                tokenInfoMap = new HashMap<>();
             }
-            fileIdAccessTokenMap.get(fileId).put(userName, tokenInfo);
+            tokenInfoMap.put(userName, tokenInfo);
         }
+
+        // put the tokenInfoMap back to the shared cache, so other servers can see changes
+        fileIdAccessTokenMap.put(fileId, tokenInfoMap);
+
+        logger.debug("Created Access Token for user '" + userName + "' and fileId '" + fileId + "'");
         return tokenInfo;
     }
 
@@ -182,6 +197,7 @@ public class LOOLServiceImpl implements LOOLService {
     @Override
     public NodeRef checkAccessToken(WebScriptRequest req) throws WebScriptException {
         final String fileId = req.getServiceMatch().getTemplateVars().get(WOPITokenService.FILE_ID);
+        logger.debug("Check Access Token for: " + fileId);
         if (fileId == null) {
             throw new WebScriptException("No 'fileId' parameter supplied");
         }

--- a/src/main/java/dk/magenta/libreoffice/online/service/WOPIAccessTokenInfo.java
+++ b/src/main/java/dk/magenta/libreoffice/online/service/WOPIAccessTokenInfo.java
@@ -1,5 +1,8 @@
 package dk.magenta.libreoffice.online.service;
 
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+import java.io.Serializable;
 import java.util.Date;
 
 /**
@@ -7,7 +10,10 @@ import java.util.Date;
  *
  * Created by seth on 30/04/16.
  */
-public class WOPIAccessTokenInfo {
+public class WOPIAccessTokenInfo implements Serializable {
+
+    private static final long serialVersionUID = 8344283129580208330L;
+
     private String accessToken;
     private Date issuedAt;
     private Date expiresAt;
@@ -79,5 +85,16 @@ public class WOPIAccessTokenInfo {
 
     public void setAccessToken(String accessToken) {
         this.accessToken = accessToken;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("accessToken", accessToken)
+            .append("issuedAt", issuedAt)
+            .append("expiresAt", expiresAt)
+            .append("fileId", fileId)
+            .append("userName", userName)
+            .toString();
     }
 }


### PR DESCRIPTION
The `fileIdAccessTokenMap` map is a local map to the server. This map
holds information about opened documents by users with Collabora.
In clustered environments, this map must be shared by all Alfresco
nodes.